### PR TITLE
Fix for Xcode errors related to boost-for-react-native dependency

### DIFF
--- a/ios/RNAdConsent.xcodeproj/project.pbxproj
+++ b/ios/RNAdConsent.xcodeproj/project.pbxproj
@@ -237,7 +237,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../../ios/Pods/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (

--- a/ios/RNAdConsent.xcodeproj/project.pbxproj
+++ b/ios/RNAdConsent.xcodeproj/project.pbxproj
@@ -213,7 +213,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../../ios/Pods/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
Fixes the XCode errors that seem to be coming from "boost-for-react-native" project. Modified the header search path, as recommended in SO: https://stackoverflow.com/a/51794706